### PR TITLE
Fix/crash

### DIFF
--- a/EconExp1_TimePrefPronoun1_intro/models.py
+++ b/EconExp1_TimePrefPronoun1_intro/models.py
@@ -14,9 +14,8 @@ from EconExp1_TimePrefPronoun1_questionaire.models import (
     WaitingPeriod,
     GainedAmount,
     Treatment,
+    Subsession as QuestionaireSubsession
 )
-
-import json
 
 
 author = 'Josie_NTULAB'
@@ -39,14 +38,9 @@ class Subsession(BaseSubsession):
     num_questions = models.IntegerField() # 實際上的回合數
 
     def creating_session(self):
-        # 從 session config 讀取（預設定義在 settings.py 中 SESSION_CONFIGS，但可在網頁的「Create a new session / Configure session」 中修改）
-        config = self.session.config
-        json_string = config['available_waiting_periods']
-        WaitingPeriod.list = json.loads(json_string)
-
-        json_string = config['available_gained_amounts']
-        GainedAmount.list =  json.loads(json_string)
-
+        # 確保 `WaitingPeriod/GainedAmount` 有從 session config 載入好。
+        QuestionaireSubsession.load_from_session_config_if_needed(self.session.config)
+        
         self.num_questions = len(WaitingPeriod.list) * len(GainedAmount.list)
 
         for p in self.get_players():

--- a/EconExp1_TimePrefPronoun1_questionaire/models.py
+++ b/EconExp1_TimePrefPronoun1_questionaire/models.py
@@ -11,6 +11,7 @@ from otree.api import (
 
 from enum import Enum
 import random
+import json
 
 author = 'Josie_NTULAB'
 
@@ -63,7 +64,19 @@ class OptionOfGetMoney(Enum):
 
 
 class Subsession(BaseSubsession):
+    @staticmethod
+    def load_from_session_config_if_needed(session_config):
+        # 從 session config 讀取（預設定義在 settings.py 中 SESSION_CONFIGS，但可在網頁的「Create a new session / Configure session」 中修改）
+        if len(WaitingPeriod.list) == 0:
+            json_string = session_config['available_waiting_periods']
+            WaitingPeriod.list = json.loads(json_string)
+
+        if len(GainedAmount.list) == 0:
+            json_string = session_config['available_gained_amounts']
+            GainedAmount.list = json.loads(json_string)
+
     def creating_session(self):
+        Subsession.load_from_session_config_if_needed(self.session.config)
         for p in self.get_players():
             p.treatment_pronoun_included = Treatment.get_pronoun_included(p)
 

--- a/EconExp1_TimePrefPronoun1_questionaire/pages.py
+++ b/EconExp1_TimePrefPronoun1_questionaire/pages.py
@@ -38,14 +38,14 @@ class GetMoneyNowOrFuture(Page):
         q_params_pairs = self.participant.vars[Constants.key_q_params_pairs]
 
         # 設定每一 round 的參數，並寫入 db
-        idx = self.round_number - 1 # list 從0開始 但 round_bnumber 從1開始
+        idx = self.round_number - 1 # list 從0開始 但 round_number 從1開始
         pair = q_params_pairs[idx]
         self.player.waiting_period = pair['waiting_period']
         self.player.gained_amount = pair['gained_amount']
 
     def select_questionaire(self):
         q_params_pairs = self.participant.vars[Constants.key_q_params_pairs]
-        selected_idx = randint(1, Constants.actual_num_rounds()) - 1 # list 的 index 從0開始 但 round_bnumber 從1開始
+        selected_idx = randint(1, Constants.actual_num_rounds()) - 1 # list 的 index 從0開始 但 round_number 從1開始
         selected_q_parama_pair = q_params_pairs[selected_idx]
         selected_player = self.player.in_all_rounds()[selected_idx]
         selected_player.is_selected = True

--- a/EconExp1_TimePrefPronoun1_questionaire/pages.py
+++ b/EconExp1_TimePrefPronoun1_questionaire/pages.py
@@ -3,6 +3,8 @@ from ._builtin import Page, WaitPage
 from .models import Constants, WaitingPeriod, GainedAmount
 from random import randint
 import random
+from EconExp1_TimePrefPronoun1_questionaire.models import Subsession as QuestionaireSubsession
+
 
 class GetMoneyNowOrFuture(Page):
     form_model = 'player'
@@ -30,6 +32,9 @@ class GetMoneyNowOrFuture(Page):
         return q_params_pairs
 
     def setup_questionaire_parameters_pairs(self):
+        # 確保 `WaitingPeriod/GainedAmount` 有從 session config 載入好。
+        QuestionaireSubsession.load_from_session_config_if_needed(self.session.config)
+
         # 如果還不存在，就現在產生「週數和金額的組合」並存起來
         # 如果已經存在，就取出
         if Constants.key_q_params_pairs not in self.participant.vars: 


### PR DESCRIPTION
https://josieslab.slack.com/archives/G012NFPMMCG/p1588049370041900?thread_ts=1587980483.025100&cid=G012NFPMMCG

比較接近 workaround。
在 `questionaire` 這個 `app` seesion  在 create 時，以及 page display 之前，
再次確認是否有從 session config 載入好 `WaitingPeriod/GainedAmount`，若沒有就載入。
以避免 `WaitingPeriod/GainedAmount` 是空的導致的 crash。