### PR TITLE
Actual Fix: 「Failed to create session: "2 is not in list"」

### DIFF
--- a/EconExp1_TimePrefPronoun1_intro/models.py
+++ b/EconExp1_TimePrefPronoun1_intro/models.py
@@ -42,8 +42,9 @@ class Subsession(BaseSubsession):
         
         self.num_questions = len(WaitingPeriod.list) * len(GainedAmount.list)
         
-        Treatment.create_pronoun_list_if_needed(self.get_players())
-        Treatment.create_speech_speed_list_if_needed(self.get_players())
+        Treatment.prepare_participant_ids_if_needed(self.get_players())
+        Treatment.prepare_pronoun_list(self.get_players())
+        Treatment.prepare_speech_speed_list(self.get_players())
         for p in self.get_players():
             p.treatment_pronoun = Treatment.get_pronoun(p)
             p.treatment_speech_speed = Treatment.get_speech_speed(p)

--- a/EconExp1_TimePrefPronoun1_questionaire/models.py
+++ b/EconExp1_TimePrefPronoun1_questionaire/models.py
@@ -30,9 +30,12 @@ class GainedAmount(object):
 class Treatment(object):    
     participant_ids = []
     
-    def create_participant_ids_if_needed(all_players):
-        if len(Treatment.participant_ids) > 0:
+    def prepare_participant_ids_if_needed(all_players):
+        noNeedToReCreate = len(Treatment.participant_ids) == len(all_players)
+        if noNeedToReCreate:
             return
+
+        Treatment.participant_ids.clear()
         for p in all_players:
             pid = p.participant.id_in_session
             if pid not in Treatment.participant_ids:
@@ -41,10 +44,9 @@ class Treatment(object):
     available_pronoun_list = ['我']
     pronoun_list = []
     
-    def create_pronoun_list_if_needed(all_players): # 事先準備好所有受試者的 pronoun 們
-        if len(Treatment.pronoun_list) > 0:
-            return
-        Treatment.create_participant_ids_if_needed(all_players)
+    def prepare_pronoun_list(all_players): # 事先準備好所有受試者的 pronoun 們
+        Treatment.pronoun_list.clear()
+        Treatment.prepare_participant_ids_if_needed(all_players)
         for each_pronoun in Treatment.available_pronoun_list:
             count = int(len(Treatment.participant_ids) / len(Treatment.available_pronoun_list)) # 例如有5人，平均分配兩組 treatment，那就是 5/2 = 2（不取餘數）
             Treatment.pronoun_list.extend( [each_pronoun] * count ) # “python - Create list of single item repeated N times - Stack Overflow” https://stackoverflow.com/questions/3459098/create-list-of-single-item-repeated-n-times
@@ -66,10 +68,9 @@ class Treatment(object):
     available_speech_speed_list = [0.7, 0.8, 0.9]
     speech_speed_list = []
 
-    def create_speech_speed_list_if_needed(all_players): # 事先準備好所有受試者的 speech_speed 們
-        if len(Treatment.speech_speed_list) > 0:
-            return
-        Treatment.create_participant_ids_if_needed(all_players)
+    def prepare_speech_speed_list(all_players): # 事先準備好所有受試者的 speech_speed 們
+        Treatment.speech_speed_list.clear()
+        Treatment.prepare_participant_ids_if_needed(all_players)
         for each_speed in Treatment.available_speech_speed_list:
             count = int(len(Treatment.participant_ids) / len(Treatment.available_speech_speed_list)) # 例如有5人，平均分配兩組 treatment，那就是 5/2 = 2（不取餘數）
             Treatment.speech_speed_list.extend( [each_speed] * count ) # “python - Create list of single item repeated N times - Stack Overflow” https://stackoverflow.com/questions/3459098/create-list-of-single-item-repeated-n-times
@@ -124,8 +125,8 @@ class Subsession(BaseSubsession):
 
     def creating_session(self):
         Subsession.load_from_session_config_if_needed(self.session.config)
-        Treatment.create_pronoun_list_if_needed(self.get_players())
-        Treatment.create_speech_speed_list_if_needed(self.get_players())
+        Treatment.prepare_pronoun_list(self.get_players())
+        Treatment.prepare_speech_speed_list(self.get_players())
         for p in self.get_players():
             p.treatment_pronoun = Treatment.get_pronoun(p)
             p.treatment_speech_speed = Treatment.get_speech_speed(p)


### PR DESCRIPTION
"Fix: Shows "Failed to create session: "2 is not in list"" when creating session. by cczallen · Pull Request #24 · josie-ntulab/otree"
#24
👆並未修復。

"Try to Fix: Shows "Failed to create session: "2 is not in list"" when creating session by cczallen · Pull Request #25 · josie-ntulab/otree"
https://github.com/josie-ntulab/otree/pull/25
👆並未修復。

***


原因是在「Sessions Tab」重複 create session 的時候 Treatment 中的 class 成員變數已固定，不會再重新生成，但重複 create 的時候可能會改 Number of participants。
所以 會 list index out of bound

Potential issue: 如果有兩個以上的 sessions 同時在運行，而 participant_ids是用 Treatment 中的 class來做，如果他們的確是存取到同一人，那資訊可能會錯亂（不同 session 的 participants 不同）。
(Updated: 詳細檢視過後，在目前的 case，participant_ids create 後立刻就會存進 participant.vars 中，所以應該不至於會被另個 session 在中途修改掉。毋須擔心。)